### PR TITLE
Fixed generic filter search on xsd:string

### DIFF
--- a/src/OpenSkos/ApiFilter.php
+++ b/src/OpenSkos/ApiFilter.php
@@ -251,6 +251,7 @@ final class ApiFilter
                             $filterField = 'd_'.$shortfield;
                             break;
                         case 'csv':
+                        case 'xsd:string':
                             $filterField = 's_'.$shortfield;
                             break;
                         default:


### PR DESCRIPTION
This PR fixes the `?filter[<predicate>]=value` parameters for 9/10 fields